### PR TITLE
from so question

### DIFF
--- a/src/components/ItemWrapper.vue
+++ b/src/components/ItemWrapper.vue
@@ -1,0 +1,44 @@
+    <template>
+      <item-card :item="item"></item-card>
+    </template>
+
+    <script>
+    import ItemCard from './ItemCard.vue';
+    import data from '../data/data';
+
+    export default {
+      components: {
+        ItemCard,
+      },
+      props: {
+        stackNameUrl: {
+          required: true,
+          type: String,
+        },
+      },
+      data() {
+        return {
+          item: {},
+        }
+      },
+      computed: {
+        isItemLoaded() {
+          return this.item && this.item.name;
+        },
+        stackName() {
+          return decodeURI(this.stackNameUrl).replace(/-/g, ' ');
+        }
+
+      },
+      created() {
+        this.item = data.find( fw => fw.name === this.stackName);
+      }
+    }
+    </script>
+
+    <style>
+
+    </style>
+
+
+

--- a/src/components/SearchPage.vue
+++ b/src/components/SearchPage.vue
@@ -25,7 +25,11 @@
 		<!-- end of checkboxes -->
     <div class="card-columns">
 			<!-- iterate data -->
-      <item-card v-for="(item, index) in filteredData" :key="index" :item="item"></item-card>
+      <template v-for="(item, index) in filteredData" >
+      <router-link :to="'/item/' + sanitize(item.name)" :key="index">
+        <item-card  :key="index" :item="item"></item-card>
+      </router-link>
+      </template>
     </div>
   </div>
 </template>
@@ -90,6 +94,9 @@ export default {
 		};
 	},
 	methods: {
+    sanitize(s){
+      return s.replace(/ /g, '-');
+    },
 		getfilteredData: function() {
 			this.filteredData = data;
 			let filteredDataByfilters = [];

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -1,15 +1,22 @@
-import Vue from 'vue';
-import Router from 'vue-router';
-import SearchPage from '@/components/SearchPage';
+    import Vue from 'vue';
+    import Router from 'vue-router';
+    import SearchPage from '@/components/SearchPage';
+    import ItemWrapper from '@/components/ItemWrapper';
 
-Vue.use(Router);
+    Vue.use(Router);
 
-export default new Router({
-	routes: [
-		{
-			path: '/',
-			name: 'SearchPage',
-			component: SearchPage
-		}
-	]
-});
+    export default new Router({
+      routes: [
+        {
+          path: '/',
+          name: 'SearchPage',
+          component: SearchPage
+        },
+        {
+          path: '/item/:stackNameUrl',
+          name: 'ItemWrapper',
+          component: ItemWrapper,
+          props: true,
+        },
+      ]
+    });


### PR DESCRIPTION
With another fix, to solve a request here:
https://stackoverflow.com/questions/51733639/basic-vue-help-accessing-js-object-values-in-component/51736826?noredirect=1#comment90466810_51736826

The PR has the changes from the original SO answer. On top of that, now the `SearchPage`  has a `sanitize` method to encode stack names with '-' instead of spaces, and the `ItemWrapper` component now removes the dashes for spaces when retrieving the data.